### PR TITLE
v1.0.1 Release

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 # 1. node_exporter
 # 2. cadvisor
 
-# It is used cadvisor to execute 2 programs (cadvisor and node_exporter) at the same time
+# It is used supervisor to execute 2 programs (cadvisor and node_exporter) at the same time
 # Docs: http://supervisord.org/
 
 # IMPORTANT! node_exporter cannot be installed on the alpine version

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,21 +1,31 @@
-FROM gcr.io/google-containers/cadvisor:v0.36.0 as cadvisor
+# This Dockerfile needs 2 binaries:
+# 1. node_exporter
+# 2. cadvisor
 
-FROM alpine:edge
+# It is used cadvisor to execute 2 programs (cadvisor and node_exporter) at the same time
+# Docs: http://supervisord.org/
 
-RUN apk --no-cache add libc6-compat device-mapper findutils zfs && \
-    apk --no-cache add thin-provisioning-tools --repository http://dl-3.alpinelinux.org/alpine/edge/main/ && \
-    echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
-    rm -rf /var/cache/apk/*
+# IMPORTANT! node_exporter cannot be installed on the alpine version
+# used in the cadvisor image, whereas it can be installed on the latest
+# Alpine version
 
-COPY --from=cadvisor /usr/bin/cadvisor /usr/bin/cadvisor
+ARG UPSTREAM_VERSION
 
-RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-	prometheus-node-exporter
+#################
+## 1. Exporter ##
+#################
+FROM alpine as exporter
+RUN apk --no-cache update && \
+    apk --no-cache add prometheus-node-exporter
+
+#################
+## 2. Cadvisor ##
+#################
+FROM gcr.io/cadvisor/cadvisor:$UPSTREAM_VERSION
+
+COPY --from=exporter /usr/bin/node_exporter /usr/bin/node_exporter
 
 RUN apk add supervisor
-
 COPY supervisord.conf /etc/supervisord/supervisord.conf
-
-RUN rm /bin/*
 
 ENTRYPOINT ["supervisord","-c","/etc/supervisord/supervisord.conf"]

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,13 +1,17 @@
 {
   "name": "dappnode-exporter.dnp.dappnode.eth",
-  "version": "0.1.1",
+  "version": "1.0.1",
+  "upstreamVersion": "v0.40.0",
+  "upstreamRepo": "google/cadvisor",
+  "upstreamArg": "UPSTREAM_VERSION",
   "description": "Package responsible of get metrics from the system to be able to check its healthy, based on the tools cadvisor and node_exporter.",
   "shortDescription": "DAppNode prometheus exporter",
   "type": "service",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
   "contributors": [
     "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)",
-    "DAppLion <dapplion@giveth.io> (https://github.com/dapplion)"
+    "DAppLion <dapplion@giveth.io> (https://github.com/dapplion)",
+    "Pablo Mendez <pablo@dappnode.io> (https://github.com/pablomendezroyo)"
   ],
   "categories": ["Monitoring"],
   "links": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,17 @@
 version: "3.4"
 services:
   dappnode-exporter.dnp.dappnode.eth:
-    build: ./build
-    image: "dappnode-exporter.dnp.dappnode.eth:0.1.1"
+    build: 
+      context: build
+      args:
+        UPSTREAM_VERSION: v0.40.0
+    image: "dappnode-exporter.dnp.dappnode.eth:1.0.1"
     restart: always
     volumes:
       - "/:/rootfs:ro"
       - "/sys:/sys:ro"
       - "/sys:/host/sys:ro"
-      - "/cgroup:/cgroup:ro"
+      - "/dev/disk/:/dev/disk:ro"
       - "/proc:/host/proc:ro"
       - "/var/run:/var/run:rw"
       - "/var/lib/docker:/var/lib/docker:ro"


### PR DESCRIPTION
## Changelog:
- Dockerfile refactor: use of cadvisor docker image instead of taking the binary. There are some libraries needed by the binary. Download `prometheus_node_exporter` binary in a previous stage
- Volumes refactor: taking into account official docs
- Bump upstream version to v0.40.0

This PR fixes the main bug of the exporter not pushing metrics. Whereas it will still fail to get a few metrics from the host (CPU and memory). This is due to a Debian migration to **cgroups v2** that should be eventually fully supported by cadvisor


Special thanks to @androolloyd and Shoryuken for pushing and researching about this fix

