### PR TITLE
Disable x cpu metrics in cadvisor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,3 +22,4 @@ services:
       - "/sys:/sys:ro"
       - "/var/lib/docker/:/var/lib/docker:ro"
     image: "cadvisor.dappnode-exporter.dnp.dappnode.eth:1.0.1"
+    command: '--disable_metrics="percpu"'


### PR DESCRIPTION
Since cAdvisor does not have the option to enable "total" cpu and "percpu" metrics in the same time, we need to disable "percpu" metrics to force "total" cpu metrics, used by ethical metrics dashboard.

Disabling "percpu" metrics shouldnt break any DMS nodes, also, some dappnodes seem to already be using only "total" metrics by default.