### PR TITLE
Fix node exporter volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,12 @@ services:
     build:
       context: node_exporter
       args:
-        NODE_EXPORTER_UPSTREAM_VERSION: v1.5.0
+        NODE_EXPORTER_UPSTREAM_VERSION: v1.6.1
     restart: always
     volumes:
-      - "/proc:/host/proc:ro"
-      - "/sys:/host/sys:ro"
+      - "/:/host:ro,rslave"
+    command:
+      - "--path.rootfs=/host"
     image: "node-exporter.dappnode-exporter.dnp.dappnode.eth:1.0.3"
   cadvisor:
     build:


### PR DESCRIPTION
fixed node exporter volumes to point to "/" again. Needed to specify rootfs path in compose, this was not necessary in lower `node exporter` versions

![Screenshot_20231010_112713](https://github.com/dappnode/DAppNodePackage-exporter/assets/36164126/6460f6a8-675d-43b5-b82f-fce9ea8362e5)
