### PR TITLE
Add missing instructions for cadvisor

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "dappnode-exporter.dnp.dappnode.eth",
   "version": "1.0.3",
-  "upstreamVersion": "v0.47.1",
+  "upstreamVersion": "v0.47.2",
   "upstreamRepo": "google/cadvisor",
   "upstreamArg": "UPSTREAM_VERSION",
   "description": "Package responsible for getting metrics from the system to be able to check its health, based on the tools cadvisor and node_exporter.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,16 @@ services:
       args:
         UPSTREAM_VERSION: v0.47.1
     restart: always
+    privileged: true
     volumes:
       - "/:/rootfs:ro"
-      - "/var/run:/var/run:rw"
+      - "/var/run:/var/run:ro"
       - "/sys:/sys:ro"
       - "/var/lib/docker/:/var/lib/docker:ro"
+      - "/dev/disk/:/dev/disk:ro"
+    devices:
+      - "/dev/kmsg:/dev/kmsg"
+
     image: "cadvisor.dappnode-exporter.dnp.dappnode.eth:1.0.3"
   stakers-metrics:
     build:


### PR DESCRIPTION
Add missing instructions for cadvisor.

Refernce: https://github.com/google/cadvisor#quick-start-running-cadvisor-in-a-docker-container