### PR TITLE
Use new getJsonRpcApiFromDnpName from types 31

### DIFF
--- a/stakers-metrics/package.json
+++ b/stakers-metrics/package.json
@@ -24,7 +24,7 @@
     "@typescript-eslint/parser": "5.0.0"
   },
   "dependencies": {
-    "@dappnode/types": "^0.1.23",
+    "@dappnode/types": "^0.1.31",
     "@types/node": "^20.2.4",
     "@types/express": "^4.17.17",
     "axios": "^1.4.0",

--- a/stakers-metrics/src/utils.ts
+++ b/stakers-metrics/src/utils.ts
@@ -8,23 +8,22 @@ import logger from "./logger.js";
  * @param type - The type of client (execution or consensus).
  * @returns The client URL for the specified network and type, or undefined if not found.
  */
-export function getClientUrl(network: typeof networks[number], type: "execution" | "consensus"): string | undefined {
-  // Get the environment variable key for the specified type and network.
-  const envKey = `_DAPPNODE_GLOBAL_${type.toUpperCase()}_CLIENT_${network.toUpperCase()}`;
-
-  // Check if the environment variable is defined.
+export function getClientUrl(network: typeof networks[number], clientType: "execution" | "consensus"): string | undefined {
+  // Get the dnpname of the client we want to call via env variable.
+  const envKey = `_DAPPNODE_GLOBAL_${clientType.toUpperCase()}_CLIENT_${network.toUpperCase()}`;
   const envValue = process.env[envKey];
-  if (envValue !== undefined) {
-    // Call the appropriate function to get the complete URL.
-    const clientUrl = getJsonRpcApiFromDnpName(envValue)
 
-    // Return the complete client URL.
-    return clientUrl;
+  try {
+    // If envValue is undefined, the function will return undefined by default. If not, it will try to get the client URL from the dnpname.
+    return envValue ? getJsonRpcApiFromDnpName(envValue) : undefined;
+  } catch (error) {
+    logger.error(`Error getting client URL from the dnp ${envKey} with value ${envValue}: ${error}`);
+    // Depending on how you want to handle errors, you could also return undefined here,
+    // or rethrow the error after logging it.
+    return undefined;
   }
-
-  // Return undefined if environment variable is not defined.
-  return undefined;
 }
+
 
 export async function jsonRPCapiCallExecution(
     url: string,

--- a/stakers-metrics/src/utils.ts
+++ b/stakers-metrics/src/utils.ts
@@ -1,4 +1,4 @@
-import { networks, getJsonRpcApiFromDnpName } from "@dappnode/types";
+import { getJsonRpcApiFromDnpName, Network} from "@dappnode/types";
 import axios, { AxiosError } from "axios";
 import logger from "./logger.js"; 
 
@@ -8,7 +8,7 @@ import logger from "./logger.js";
  * @param type - The type of client (execution or consensus).
  * @returns The client URL for the specified network and type, or undefined if not found.
  */
-export function getClientUrl(network: typeof networks[number], clientType: "execution" | "consensus"): string | undefined {
+export function getClientUrl(network: Network, clientType: "execution" | "consensus"): string | undefined {
   // Get the dnpname of the client we want to call via env variable.
   const envKey = `_DAPPNODE_GLOBAL_${clientType.toUpperCase()}_CLIENT_${network.toUpperCase()}`;
   const envValue = process.env[envKey];

--- a/stakers-metrics/src/utils.ts
+++ b/stakers-metrics/src/utils.ts
@@ -18,8 +18,6 @@ export function getClientUrl(network: typeof networks[number], clientType: "exec
     return envValue ? getJsonRpcApiFromDnpName(envValue) : undefined;
   } catch (error) {
     logger.error(`Error getting client URL from the dnp ${envKey} with value ${envValue}: ${error}`);
-    // Depending on how you want to handle errors, you could also return undefined here,
-    // or rethrow the error after logging it.
     return undefined;
   }
 }

--- a/stakers-metrics/src/utils.ts
+++ b/stakers-metrics/src/utils.ts
@@ -1,30 +1,29 @@
-import { getUrlFromDnpName } from "@dappnode/types";
-import { networks } from "@dappnode/types";
+import { networks, getJsonRpcApiFromDnpName } from "@dappnode/types";
 import axios, { AxiosError } from "axios";
 import logger from "./logger.js"; 
 
-const urls = getUrlFromDnpName();
-
-// Define the URL mappings for execution and consensus clients
-const urlsMap = {
-    execution: {
-        mainnet: urls.executionClientMainnetUrl,
-        prater: urls.executionClientPraterUrl,
-        gnosis: urls.executionClientGnosisUrl,
-        lukso: urls.executionClientLuksoUrl,
-    },
-    consensus: {
-        mainnet: urls.consensusClientMainnetUrl,
-        prater: urls.consensusClientPraterUrl,
-        gnosis: urls.consensusClientGnosisUrl,
-        lukso: urls.consensusClientLuksoUrl,
-    },
-};
-
-// Gets the client URL for a given network and type (execution or consensus)
+/**
+ * Gets the client URL for a given network and type (execution or consensus).
+ * @param network - The network for which the client URL is required.
+ * @param type - The type of client (execution or consensus).
+ * @returns The client URL for the specified network and type, or undefined if not found.
+ */
 export function getClientUrl(network: typeof networks[number], type: "execution" | "consensus"): string | undefined {
-    const clientUrl = urlsMap[type][network];
-    return clientUrl !== undefined ? clientUrl : undefined;
+  // Get the environment variable key for the specified type and network.
+  const envKey = `_DAPPNODE_GLOBAL_${type.toUpperCase()}_CLIENT_${network.toUpperCase()}`;
+
+  // Check if the environment variable is defined.
+  const envValue = process.env[envKey];
+  if (envValue !== undefined) {
+    // Call the appropriate function to get the complete URL.
+    const clientUrl = getJsonRpcApiFromDnpName(envValue)
+
+    // Return the complete client URL.
+    return clientUrl;
+  }
+
+  // Return undefined if environment variable is not defined.
+  return undefined;
 }
 
 export async function jsonRPCapiCallExecution(

--- a/stakers-metrics/yarn.lock
+++ b/stakers-metrics/yarn.lock
@@ -28,10 +28,10 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@dappnode/types@^0.1.23":
-  version "0.1.23"
-  resolved "https://registry.yarnpkg.com/@dappnode/types/-/types-0.1.23.tgz#e349661f40402b31fa3cd8651f16aed0ca927a79"
-  integrity sha512-24O6fVfKqQHuHOgaNHvA7sbEZzYjCWxyIpFXaxnJxl4da6NRAEd+wZgzNzRQsqC5lLIQkNEc4uS+V+utgSGJuw==
+"@dappnode/types@^0.1.31":
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/@dappnode/types/-/types-0.1.31.tgz#701abac8ebc917ddc1f9a4f9be743a130375523c"
+  integrity sha512-JMQhQdsv4coFbUirNdWukCWZmxvw3L8prlCjAyJgjePGWqCcnOrgT46eV8dbHkdWaAPkBoLelcVUupFB7hRetg==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"


### PR DESCRIPTION
Whenever the JSON RPC API of a staker client is needed when collecting `syncing` or `peer_count` metrics, use the new method `getJsonRpcApiFromDnpName()` from types 0.1.31 instead of old `getUrlFromDnpName()`.

Hash to test:
/ipfs/QmTcZ1svYgkgGwFWoT6tp1SpYZ6LdRZWrFjXmE6JpdXDNP
http://my.dappnode/system/add-ipfs-peer/%2Fdns4%2F53650f79ab75c6ff.dyndns.dappnode.io%2Ftcp%2F4001%2Fipfs%2F12D3KooWE1kBVj1Xp8kJdTFJ5J4rvfhsFLcg8pv3EJpkyyyamGJ1